### PR TITLE
Add support for Matomo v5.0

### DIFF
--- a/API.php
+++ b/API.php
@@ -6,20 +6,20 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\TrackingOptOut;
+namespace Piwik\Plugins\AnalyticsOptOut;
 
 use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
 use Piwik\Tracker\IgnoreCookie;
 
 /**
- * API for plugin TrackingOptOut
+ * API for plugin AnalyticsOptOut
  * @method static API getInstance()
  */
 class API extends \Piwik\Plugin\API {
     /**
      * This method will return whether the user is tracked or not.
      *
-     * Call: index.php?module=API&method=TrackingOptOut.isTracked
+     * Call: index.php?module=API&method=AnalyticsOptOut.isTracked
      *
      * @return array
      */
@@ -34,7 +34,7 @@ class API extends \Piwik\Plugin\API {
     /**
      * Sets the ignore cookie, so the user is not tracked any longer.
      *
-     * Call: index.php?module=API&method=TrackingOptOut.doIgnore
+     * Call: index.php?module=API&method=AnalyticsOptOut.doIgnore
      *
      * @return void
      */
@@ -51,7 +51,7 @@ class API extends \Piwik\Plugin\API {
     /**
      * Removes the ignore cookie, so the user is tracked from now on.
      *
-     * Call: index.php?module=API&method=TrackingOptOut.doTrack
+     * Call: index.php?module=API&method=AnalyticsOptOut.doTrack
      *
      * @return void
      */

--- a/AnalyticsOptOut.php
+++ b/AnalyticsOptOut.php
@@ -6,8 +6,8 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\TrackingOptOut;
+namespace Piwik\Plugins\AnalyticsOptOut;
 
-class TrackingOptOut extends \Piwik\Plugin {
+class AnalyticsOptOut extends \Piwik\Plugin {
 
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
-    "name":        "TrackingOptOut",
-    "description": "Provide endpoints to opt-out, opt-in or get status of visitors tracking. So you can implement a custom HTML, CSS and JS to realize custom-style tracking management.",
-    "version":     "v1.0.2-gewisweb",
+    "name":        "AnalyticsOptOut",
+    "description": "Provide endpoints to opt-out, opt-in or get status of visitors analytics. So you can implement a custom HTML, CSS and JS to realize custom-style tracking management.",
+    "version":     "v1.0.3-gewisweb",
     "theme":       false,
     "require": {
-        "piwik": ">=4.0.0,<5.0.0",
+        "piwik": ">=4.0.0,<6.0.0",
         "php":   ">=7.0.0"
     },
     "authors":     [
@@ -34,7 +34,7 @@
     "keywords":    [
         "opt out",
         "opt in",
-        "tracking",
+        "analytics",
         "ajax"
     ]
 }


### PR DESCRIPTION
Adds support for Matomo v5.0 and directly bump the version to `v1.0.3-gewisweb`.

Closes GH-4.